### PR TITLE
Added the start of sshd to init its configuration

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,8 @@
   pip: name=awscli state=present
 - name: 'Ensure ssh installed'
   yum: pkg=openssh-server state=installed
+- name: 'Start sshd'
+  service: name=sshd state=started
 - name: 'Ensure cron installed'
   yum: pkg=cronie state=installed
 


### PR DESCRIPTION
Testing the role with the centos:7 docker container I got this error:
```
TASK [j0lly.ssh-aws : ensure AuthorizedKeysCommandUser in sshd_config] *********
fatal: [centos_base_image]: FAILED! => {"changed": false, "failed": true, "msg": "failed to validate: rc:1 error:Could not load host key: /etc/ssh/ssh_host_rsa_key\r\nCould not load host key: /etc/ssh/ssh_host_ecdsa_key\r\nCould not load host key: /etc/ssh/ssh_host_ed25519_key\r\nsshd: no hostkeys available -- exiting.\r\n"}
```

The cause is missing host key files
```
[root@449dcdd829b8 /]# ls /etc/ssh/
moduli  sshd_config
```

Starting sshd solves the problem because at first run it bootstraps its configurations and keys (when missing)